### PR TITLE
Replace cabal with stack

### DIFF
--- a/ghc-cross/Dockerfile
+++ b/ghc-cross/Dockerfile
@@ -10,7 +10,7 @@ RUN tar xvfj ghc-7.8.4-src.tar.bz2
 WORKDIR /tmp/ghc-7.8.4
 
 COPY build.mk /tmp/ghc-7.8.4/mk/build.mk
-RUN ./configure --target=x86_64-pc-linux-musl --with-gcc=musl-gcc --with-ld=ld --with-nm=nm --with-ar=ar  --with-ranlib=ranlib --prefix=/opt/ghc-cross
+RUN ./configure --target=x86_64-pc-linux-musl --with-gcc=musl-gcc --with-ld=ld --with-nm=nm --with-ar=ar --with-ranlib=ranlib --prefix=/opt/ghc-cross
 
 # stole this from https://github.com/redneb/ghc-alt-libc, thanks!
 COPY fix-execvpe-signature-ghc-7.8.4.patch /tmp/fix-execvpe.patch
@@ -20,7 +20,7 @@ RUN patch -p1 </tmp/fix-execvpe.patch
 RUN sed -i s/terminfo// ghc.mk
 RUN sed -i s/terminfo// utils/ghc-pkg/ghc-pkg.cabal
 RUN sed -i s/unix,/unix/ utils/ghc-pkg/ghc-pkg.cabal
-RUN sed -i '1{p; s/.*/#define BOOTSTRAPPING/}' utils/ghc-pkg/Main.hs    
+RUN sed -i '1{p; s/.*/#define BOOTSTRAPPING/}' utils/ghc-pkg/Main.hs
 
 # update config.sub in libffi, so it supports x86_64-pc-linux
 RUN sed -i 's,chmod,cp /usr/share/misc/config.sub libffi/build/config.sub \&\& chmod,' libffi/ghc.mk

--- a/ghc-musl/Dockerfile
+++ b/ghc-musl/Dockerfile
@@ -1,8 +1,10 @@
 FROM alpine:latest
-COPY get-last-layer.sh build.mk fix-execvpe-signature-ghc-7.8.4.patch /tmp/
+
+WORKDIR /tmp
+COPY get-last-layer.sh build.mk fix-execvpe-signature-ghc-7.8.4.patch ./
 RUN : "Layer 1: fully working basic GHC in /usr/local" && \
-    mkdir /tmp/ghc && \
-    cd /tmp/ghc && \
+    mkdir ghc && \
+    cd ghc && \
     apk add --update curl xz alpine-sdk perl gmp-dev file gmp openssh openssl zlib-dev strace vim less jq ncurses-dev bash autoconf && \
     cd /tmp && \
     curl -sSLO https://nixos.org/releases/patchelf/patchelf-0.8/patchelf-0.8.tar.bz2 && \
@@ -42,7 +44,6 @@ RUN : "Layer 1: fully working basic GHC in /usr/local" && \
 
 ENV PATH=/root/.cabal/bin:$PATH
 RUN : "Layer 2: cabal-install, but only the binary, no executables" && \
-    cd /tmp && \
     curl -sSLO https://hackage.haskell.org/package/cabal-install-1.22.4.0/cabal-install-1.22.4.0.tar.gz && \
     tar xvfz cabal-install-1.22.4.0.tar.gz && \
     cd cabal-install-1.22.4.0 && \
@@ -50,8 +51,8 @@ RUN : "Layer 2: cabal-install, but only the binary, no executables" && \
     cd / && \
     rm -rf /root/.ghc /tmp/cabal-install-1.22.4.0* /tmp/cabal- /root/.cabal/lib /root/.cabal/share
 
+WORKDIR /root/.cabal
 RUN : "Layer 3: cabal-install from stackage and stackage is set up" && \
-    cd /root/.cabal && \
     cabal update && \
     curl -sSL 'https://www.stackage.org/lts-2.12/cabal.config?global=true' >>config && \
     : Waiting for https://github.com/haskell/network/commit/6afe609308b90c1fd4b185978a15d44bc1dbd678 && \
@@ -72,6 +73,7 @@ RUN : "Layer 3: cabal-install from stackage and stackage is set up" && \
     cp /root/.cabal/config /root/.cabal/config.before-stackage && \
     curl -sSL 'https://www.stackage.org/lts-2.12/cabal.config?global=true' >>/root/.cabal/config
 
+WORKDIR /tmp
 RUN : "Layer 4: install some packages" && \
     : the ncurses hackage package is a little bit broken && \
     ln -s /usr/include /usr/include/ncursesw && \
@@ -108,9 +110,8 @@ RUN : "Layer 4: install some packages" && \
                            network-transport-tcp tasty tasty-hunit safecopy \
                            sodium unbounded-delays && \
     : template-default needs jailbraking && \
-    cd /tmp && \
     cabal unpack -d template-default template-default && \
-    cd /tmp/template-default/* && \
+    cd template-default/* && \
     sed s/2.9/2.10/ -i template-default.cabal && \
     cabal install --global --only-dependencies && \
     cabal install --global && \
@@ -169,4 +170,5 @@ RUN : "Layer 4: install some packages" && \
 # TODO: network-protocol-xmpp supports libgsasl only, not cyrus-sasl-dev,
 #       either have to fix that or put a libgsasl-dev into Alpine
 
+WORKDIR /
 CMD /bin/sh

--- a/ghc-musl/Dockerfile
+++ b/ghc-musl/Dockerfile
@@ -36,8 +36,9 @@ RUN : "Layer 1: fully working basic GHC in /usr/local" && \
 
 ENV PATH=/root/.cabal/bin:$PATH
 RUN : "Layer 2: cabal-install, but only the binary, no executables" && \
-    curl -L https://hackage.haskell.org/package/cabal-install-1.22.4.0/cabal-install-1.22.4.0.tar.gz | tar xz && \
-    cd cabal-install-1.22.4.0 && \
+    curl -L https://hackage.haskell.org/package/cabal-install-1.22.6.0/cabal-install-1.22.6.0.tar.gz | tar xz && \
+    cd cabal-install-1.22.6.0 && \
+    sed -i 's/export TMPDIR=.*/export TMPDIR=$(mktemp -t cabal-XXXXXX -d)/' bootstrap.sh && \
     EXTRA_CONFIGURE_OPTS=--disable-library-profiling ./bootstrap.sh && \
     : Clean up to keep the image small && \
     rm -rf /tmp/* /root/.ghc /root/.cabal/{lib,share}
@@ -66,28 +67,28 @@ RUN : "Layer 4: install some packages" && \
     cabal install --global alex happy && \
     cabal install --global c2hs && \
     cabal install --global gtk2hs-buildtools && \
-    cabal install --global attoparsec fgl haskell-src haskell-src-exts haskell-src-meta hashable html HUnit \
-                           parallel QuickCheck regex-base regex-compat regex-posix split syb \
-                           unordered-containers vector primitive async bytedump unix-bytestring colour \
-                           conduit criterion crypto-api cryptohash curl data-accessor-template \
-                           data-default data-memocombinators digest elerea filemanip foldl Glob \
-                           lens haskeline hflags hit hslogger HsOpenSSL hspec hybrid-vectors \
-                           kan-extensions lens-datetime linear mime-mail MissingH modular-arithmetic \
-                           monad-loops netwire network-conduit pipes pipes-bytestring pipes-safe \
-                           pipes-zlib pretty-show random-fu regex-tdfa regex-tdfa-rc regex-tdfa-text \
-                           SafeSemaphore snap snap-blaze statistics statvfs \
-                           temporary test-framework test-framework-hunit test-framework-th \
-                           test-framework-quickcheck2 thyme tls trifecta tz tzdata unix-time \
-                           utf8-string utility-ht vector-algorithms vector-th-unbox zip-archive \
-                           X11 xtest zeromq4-haskell Hfuse direct-sqlite sqlite-simple \
-                           gtk chart-gtk ncurses basic-prelude classy-prelude-conduit conduit-combinators \
-                           conduit-extra double-conversion hamlet http-client \
-                           http-client-tls http-conduit http-types path-pieces \
-                           persistent persistent-template shakespeare \
-                           shakespeare-css uuid xml-conduit yesod yesod-static \
-                           zlib-conduit acid-state clock distributed-process multimap \
-                           network-transport-tcp tasty tasty-hunit safecopy \
-                           sodium unbounded-delays && \
+    cabal install --global gtk chart-gtk && \
+    cabal install --global haskell-src haskell-src-exts haskell-src-meta && \
+    cabal install --global Glob HUnit Hfuse HsOpenSSL MissingH QuickCheck SafeSemaphore \
+                           X11 acid-state async attoparsec basic-prelude bytedump \
+                           classy-prelude-conduit clock colour conduit conduit-combinators \
+                           conduit-extra cookie criterion crypto-api crypto-pubkey \
+                           cryptohash curl data-accessor-template data-default data-memocombinators \
+                           digest direct-sqlite distributed-process double-conversion elerea fgl \
+                           filemanip foldl hamlet hashable haskeline hflags hit hslogger hspec html \
+                           http-client http-client-tls http-conduit http-types hybrid-vectors \
+                           kan-extensions lens lens-datetime linear mime-mail modular-arithmetic \
+                           monad-loops multimap ncurses netwire network-conduit network-transport-tcp \
+                           parallel parsers path-pieces persistent persistent-template pipes \
+                           pipes-bytestring pipes-safe pipes-zlib pretty-show primitive random-fu \
+                           regex-base regex-compat regex-posix regex-tdfa regex-tdfa-rc regex-tdfa-text \
+                           safecopy shakespeare shakespeare-css snap snap-blaze snap-core sodium split \
+                           sqlite-simple statistics statvfs syb tasty tasty-hunit temporary \
+                           test-framework test-framework-hunit test-framework-quickcheck2 test-framework-th \
+                           thyme tls trifecta tz tzdata unbounded-delays unix-bytestring \
+                           unix-time unordered-containers utf8-string utility-ht uuid vector \
+                           vector-algorithms vector-th-unbox x509 xml-conduit xtest yesod \
+                           yesod-static zeromq4-haskell zip-archive zlib-conduit && \
     : template-default needs jailbreaking && \
     cabal unpack -d template-default template-default && \
     cd template-default/* && \

--- a/ghc-musl/Dockerfile
+++ b/ghc-musl/Dockerfile
@@ -1,12 +1,16 @@
 FROM alpine:latest
 
+ENV GHC_VERSION      7.8.4
+ENV PATCHELF_VERSION 0.8
+ENV CABAL_VERSION    1.22.6.0
+
 WORKDIR /tmp
-COPY get-last-layer.sh build.mk fix-execvpe-signature-ghc-7.8.4.patch ./
+COPY get-last-layer.sh build.mk fix-execvpe-signature-ghc-$GHC_VERSION.patch ./
 RUN : "Layer 1: fully working basic GHC in /usr/local" && \
     apk --update add curl xz alpine-sdk perl gmp-dev file gmp openssh openssl zlib-dev strace vim less jq ncurses-dev bash autoconf && \
     : Install patchelf && \
-    curl -L https://nixos.org/releases/patchelf/patchelf-0.8/patchelf-0.8.tar.bz2 | tar xj && \
-    cd patchelf-0.8 && \
+    curl -L https://nixos.org/releases/patchelf/patchelf-$PATCHELF_VERSION/patchelf-$PATCHELF_VERSION.tar.bz2 | tar xj && \
+    cd patchelf-$PATCHELF_VERSION && \
     ./configure && \
     make install && \
     : Overlay ghc cross compiler image && \
@@ -14,10 +18,10 @@ RUN : "Layer 1: fully working basic GHC in /usr/local" && \
     sh get-last-layer.sh nilcons/ghc-musl-auto ghc-cross | tar xzO | tar xJ -C / && \
     : Compile the ghc binary distribution && \
     cd /tmp && \
-    curl -L https://www.haskell.org/ghc/dist/7.8.4/ghc-7.8.4-src.tar.bz2 | tar xj && \
-    cd ghc-7.8.4 && \
+    curl -L https://www.haskell.org/ghc/dist/$GHC_VERSION/ghc-$GHC_VERSION-src.tar.bz2 | tar xj && \
+    cd ghc-$GHC_VERSION && \
     cp -v /tmp/build.mk mk/build.mk && \
-    patch -p1 </tmp/fix-execvpe-signature-ghc-7.8.4.patch && \
+    patch -p1 </tmp/fix-execvpe-signature-ghc-$GHC_VERSION.patch && \
     PATH=/opt/ghc-cross/bin:$PATH ./configure && \
     : patch libffi bug && \
     sed -i 's,chmod,sed -i s/__gnu_linux__/1/ libffi/build/src/closures.c \&\& chmod,' libffi/ghc.mk && \
@@ -25,7 +29,7 @@ RUN : "Layer 1: fully working basic GHC in /usr/local" && \
     make binary-dist && \
     : Install the ghc binary distribution to minimize docker layer size && \
     cd /tmp && \
-    tar xjf ghc-7.8.4/ghc-7.8.4-x86_64-unknown-linux.tar.bz2 --transform 's/^ghc-7.8.4/ghc-binary-dist/' && \
+    tar xjf ghc-$GHC_VERSION/ghc-$GHC_VERSION-x86_64-unknown-linux.tar.bz2 --transform "s/^ghc-${GHC_VERSION}/ghc-binary-dist/" && \
     cd ghc-binary-dist && \
     ./configure && \
     : musl ld requires --no-pie to work for some reason with ghc && \
@@ -36,8 +40,8 @@ RUN : "Layer 1: fully working basic GHC in /usr/local" && \
 
 ENV PATH=/root/.cabal/bin:$PATH
 RUN : "Layer 2: cabal-install, but only the binary, no executables" && \
-    curl -L https://hackage.haskell.org/package/cabal-install-1.22.6.0/cabal-install-1.22.6.0.tar.gz | tar xz && \
-    cd cabal-install-1.22.6.0 && \
+    curl -L https://hackage.haskell.org/package/cabal-install-$CABAL_VERSION/cabal-install-$CABAL_VERSION.tar.gz | tar xz && \
+    cd cabal-install-$CABAL_VERSION && \
     sed -i 's/export TMPDIR=.*/export TMPDIR=$(mktemp -t cabal-XXXXXX -d)/' bootstrap.sh && \
     EXTRA_CONFIGURE_OPTS=--disable-library-profiling ./bootstrap.sh && \
     : Clean up to keep the image small && \

--- a/ghc-musl/Dockerfile
+++ b/ghc-musl/Dockerfile
@@ -5,7 +5,7 @@ RUN : "Layer 1: fully working basic GHC in /usr/local" && \
     cd /tmp/ghc && \
     apk add --update curl xz alpine-sdk perl gmp-dev file gmp openssh openssl zlib-dev strace vim less jq ncurses-dev bash autoconf && \
     cd /tmp && \
-    wget https://nixos.org/releases/patchelf/patchelf-0.8/patchelf-0.8.tar.bz2 && \
+    curl -sSLO https://nixos.org/releases/patchelf/patchelf-0.8/patchelf-0.8.tar.bz2 && \
     tar xfj patchelf-0.8.tar.bz2 && \
     cd patchelf-0.8 && \
     ./configure && make install && \
@@ -14,7 +14,7 @@ RUN : "Layer 1: fully working basic GHC in /usr/local" && \
     sh /tmp/get-last-layer.sh nilcons/ghc-musl-auto ghc-cross >ghc-cross.tar.gz && \
     tar xvfz ghc-cross.tar.gz && \
     tar -xvJ -C / -f /tmp/ghc/ghc-7.8.4-x86_64-unknown-linux-musl.tar.xz && \
-    wget https://www.haskell.org/ghc/dist/7.8.4/ghc-7.8.4-src.tar.bz2 && \
+    curl -sSLO https://www.haskell.org/ghc/dist/7.8.4/ghc-7.8.4-src.tar.bz2 && \
     tar xvfj ghc-7.8.4-src.tar.bz2 && \
     cd /tmp/ghc/ghc-7.8.4 && \
     cp -v /tmp/build.mk mk/build.mk && \
@@ -43,7 +43,7 @@ RUN : "Layer 1: fully working basic GHC in /usr/local" && \
 ENV PATH=/root/.cabal/bin:$PATH
 RUN : "Layer 2: cabal-install, but only the binary, no executables" && \
     cd /tmp && \
-    wget https://hackage.haskell.org/package/cabal-install-1.22.4.0/cabal-install-1.22.4.0.tar.gz && \
+    curl -sSLO https://hackage.haskell.org/package/cabal-install-1.22.4.0/cabal-install-1.22.4.0.tar.gz && \
     tar xvfz cabal-install-1.22.4.0.tar.gz && \
     cd cabal-install-1.22.4.0 && \
     EXTRA_CONFIGURE_OPTS=--disable-library-profiling ./bootstrap.sh && \
@@ -53,7 +53,7 @@ RUN : "Layer 2: cabal-install, but only the binary, no executables" && \
 RUN : "Layer 3: cabal-install from stackage and stackage is set up" && \
     cd /root/.cabal && \
     cabal update && \
-    curl -sS 'https://www.stackage.org/lts-2.12/cabal.config?global=true' >>config && \
+    curl -sSL 'https://www.stackage.org/lts-2.12/cabal.config?global=true' >>config && \
     : Waiting for https://github.com/haskell/network/commit/6afe609308b90c1fd4b185978a15d44bc1dbd678 && \
     : to hit Stackage LTS, until that we have a workaround, but this should be "cabal install cabal-install" && \
     cabal install --global mtl network-uri parsec random stm text zlib && \
@@ -70,7 +70,7 @@ RUN : "Layer 3: cabal-install from stackage and stackage is set up" && \
     rm -rf /root/.cabal && \
     cabal update && \
     cp /root/.cabal/config /root/.cabal/config.before-stackage && \
-    curl -sS 'https://www.stackage.org/lts-2.12/cabal.config?global=true' >>/root/.cabal/config
+    curl -sSL 'https://www.stackage.org/lts-2.12/cabal.config?global=true' >>/root/.cabal/config
 
 RUN : "Layer 4: install some packages" && \
     : the ncurses hackage package is a little bit broken && \

--- a/ghc-musl/Dockerfile
+++ b/ghc-musl/Dockerfile
@@ -3,75 +3,54 @@ FROM alpine:latest
 WORKDIR /tmp
 COPY get-last-layer.sh build.mk fix-execvpe-signature-ghc-7.8.4.patch ./
 RUN : "Layer 1: fully working basic GHC in /usr/local" && \
-    mkdir ghc && \
-    cd ghc && \
-    apk add --update curl xz alpine-sdk perl gmp-dev file gmp openssh openssl zlib-dev strace vim less jq ncurses-dev bash autoconf && \
-    cd /tmp && \
-    curl -sSLO https://nixos.org/releases/patchelf/patchelf-0.8/patchelf-0.8.tar.bz2 && \
-    tar xfj patchelf-0.8.tar.bz2 && \
+    apk --update add curl xz alpine-sdk perl gmp-dev file gmp openssh openssl zlib-dev strace vim less jq ncurses-dev bash autoconf && \
+    : Install patchelf && \
+    curl -L https://nixos.org/releases/patchelf/patchelf-0.8/patchelf-0.8.tar.bz2 | tar xj && \
     cd patchelf-0.8 && \
-    ./configure && make install && \
-    cd .. && \
-    rm -rf patchelf* && \
-    sh /tmp/get-last-layer.sh nilcons/ghc-musl-auto ghc-cross >ghc-cross.tar.gz && \
-    tar xvfz ghc-cross.tar.gz && \
-    tar -xvJ -C / -f /tmp/ghc/ghc-7.8.4-x86_64-unknown-linux-musl.tar.xz && \
-    curl -sSLO https://www.haskell.org/ghc/dist/7.8.4/ghc-7.8.4-src.tar.bz2 && \
-    tar xvfj ghc-7.8.4-src.tar.bz2 && \
-    cd /tmp/ghc/ghc-7.8.4 && \
+    ./configure && \
+    make install && \
+    : Overlay ghc cross compiler image && \
+    cd /tmp && \
+    sh get-last-layer.sh nilcons/ghc-musl-auto ghc-cross | tar xzO | tar xJ -C / && \
+    : Compile the ghc binary distribution && \
+    cd /tmp && \
+    curl -L https://www.haskell.org/ghc/dist/7.8.4/ghc-7.8.4-src.tar.bz2 | tar xj && \
+    cd ghc-7.8.4 && \
     cp -v /tmp/build.mk mk/build.mk && \
     patch -p1 </tmp/fix-execvpe-signature-ghc-7.8.4.patch && \
     PATH=/opt/ghc-cross/bin:$PATH ./configure && \
-    : "libffi has a bug, which we patch here" && \
+    : patch libffi bug && \
     sed -i 's,chmod,sed -i s/__gnu_linux__/1/ libffi/build/src/closures.c \&\& chmod,' libffi/ghc.mk && \
     make -j8 && \
     make binary-dist && \
+    : Install the ghc binary distribution to minimize docker layer size && \
     cd /tmp && \
-    mv ghc/ghc-7.8.4/ghc-7.8.4-x86_64-unknown-linux.tar.bz2 . && \
-    rm -rf ghc /opt/ghc-cross && \
-    : && \
-    : end of build, but we want to minimize docker layer sizes && \
-    : so we extract ghc here and delete the tarball && \
-    : && \
-    tar xvfj ghc-7.8.4-x86_64-unknown-linux.tar.bz2 && \
-    cd ghc-7.8.4 && \
+    tar xjf ghc-7.8.4/ghc-7.8.4-x86_64-unknown-linux.tar.bz2 --transform 's/^ghc-7.8.4/ghc-binary-dist/' && \
+    cd ghc-binary-dist && \
     ./configure && \
     : musl ld requires --no-pie to work for some reason with ghc && \
     sed -i '/C\ compiler\ link/{ s/""/"--no-pie"/ }' settings && \
     make install && \
-    cd /tmp && \
-    rm -rf ghc-7.8.4 ghc-7.8.4-x86_64-unknown-linux.tar.bz2
+    : Clean up to keep the image small && \
+    rm -rf /tmp/*
 
 ENV PATH=/root/.cabal/bin:$PATH
 RUN : "Layer 2: cabal-install, but only the binary, no executables" && \
-    curl -sSLO https://hackage.haskell.org/package/cabal-install-1.22.4.0/cabal-install-1.22.4.0.tar.gz && \
-    tar xvfz cabal-install-1.22.4.0.tar.gz && \
+    curl -L https://hackage.haskell.org/package/cabal-install-1.22.4.0/cabal-install-1.22.4.0.tar.gz | tar xz && \
     cd cabal-install-1.22.4.0 && \
     EXTRA_CONFIGURE_OPTS=--disable-library-profiling ./bootstrap.sh && \
-    cd / && \
-    rm -rf /root/.ghc /tmp/cabal-install-1.22.4.0* /tmp/cabal- /root/.cabal/lib /root/.cabal/share
+    : Clean up to keep the image small && \
+    rm -rf /tmp/* /root/.ghc /root/.cabal/{lib,share}
 
 WORKDIR /root/.cabal
 RUN : "Layer 3: cabal-install from stackage and stackage is set up" && \
     cabal update && \
-    curl -sSL 'https://www.stackage.org/lts-2.12/cabal.config?global=true' >>config && \
-    : Waiting for https://github.com/haskell/network/commit/6afe609308b90c1fd4b185978a15d44bc1dbd678 && \
-    : to hit Stackage LTS, until that we have a workaround, but this should be "cabal install cabal-install" && \
-    cabal install --global mtl network-uri parsec random stm text zlib && \
-    cabal unpack network-2.6.2.0 && \
-    cd network-2.6.2.0 && \
-    sed -i '/defined(AF_CAN)/ s/AF_CAN/NO_CAN_OF_WORMS/' Network/Socket/Types.hsc && \
-    cabal install --global && \
-    cd .. && \
-    rm -rf network-2.6.2.0 && \
+    curl -L 'https://www.stackage.org/lts/cabal.config?global=true' >>config && \
     cabal install --global cabal-install && \
-    cd / && \
-    : We regenerate the config with the stackage cabal, so that && \
-    : they are compatible. && \
-    rm -rf /root/.cabal && \
+    : We regenerate the config with the stackage cabal, so that they are compatible. && \
     cabal update && \
-    cp /root/.cabal/config /root/.cabal/config.before-stackage && \
-    curl -sSL 'https://www.stackage.org/lts-2.12/cabal.config?global=true' >>/root/.cabal/config
+    : Clean up to keep the image small && \
+    rm -rf /tmp/*
 
 WORKDIR /tmp
 RUN : "Layer 4: install some packages" && \
@@ -109,63 +88,54 @@ RUN : "Layer 4: install some packages" && \
                            zlib-conduit acid-state clock distributed-process multimap \
                            network-transport-tcp tasty tasty-hunit safecopy \
                            sodium unbounded-delays && \
-    : template-default needs jailbraking && \
+    : template-default needs jailbreaking && \
     cabal unpack -d template-default template-default && \
     cd template-default/* && \
     sed s/2.9/2.10/ -i template-default.cabal && \
     cabal install --global --only-dependencies && \
     cabal install --global && \
     cd /tmp && \
-    rm -rf template-default && \
-    : gloss needs some love and a big pile of jailbraking && \
-    cd /tmp && \
+    : gloss needs some love and a big pile of jailbreaking && \
     cabal unpack -d gloss-rendering gloss-rendering-1.9.2.1 && \
-    cd /tmp/gloss-rendering/* && \
+    cd gloss-rendering/* && \
     sed -i 's/GLUT.*/GLUT,/' gloss-rendering.cabal && \
     sed -i 's/OpenGL.*/OpenGL,/' gloss-rendering.cabal && \
     cabal install --global --only-dependencies && \
     cabal install --global && \
     cd /tmp && \
-    rm -rf gloss-rendering && \
     cabal unpack -d gloss gloss-1.9.2.1 && \
-    cd /tmp/gloss/* && \
+    cd gloss/* && \
     sed -i 's/GLUT.*==.*/GLUT,/' gloss.cabal && \
     sed -i 's/OpenGL.*==.*/OpenGL,/' gloss.cabal && \
     cabal install --global --only-dependencies && \
     cabal install --global && \
     cd /tmp && \
-    rm -rf gloss && \
-    : deepseq-th jailbraking && \
-    cd /tmp && \
+    : deepseq-th jailbreaking && \
     cabal unpack -d deepseq-th deepseq-th && \
-    cd /tmp/deepseq-th/* && \
+    cd deepseq-th/* && \
     sed -i 's/base.*,/base,/' deepseq-th.cabal && \
     sed -i 's/2.9/2.10/' deepseq-th.cabal && \
     cabal install --global --only-dependencies && \
     cabal install --global && \
     cd /tmp && \
-    rm -rf deepseq-th && \
     : "bindings-posix fixes: musl has no POSIX2_{CHAR_TERM,LOCALEDEF}" && \
-    cd /tmp && \
     cabal unpack -d bindings-posix bindings-posix && \
-    cd /tmp/bindings-posix/* && \
+    cd bindings-posix/* && \
     sed -i 's/#num _POSIX2_CHAR_TERM//' src/Bindings/Posix/Unistd.hsc && \
     sed -i 's/#num _POSIX2_LOCALEDEF//' src/Bindings/Posix/Unistd.hsc && \
     cabal install --global --only-dependencies && \
     cabal install --global && \
     cd /tmp && \
-    rm -rf bindings_posix && \
     : "hmatrix should use random in musl, not random_r, also openblas..." && \
     echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
     apk add --update openblas-dev@testing && \
-    cd /tmp && \
     cabal unpack -d hmatrix hmatrix && \
-    cd /tmp/hmatrix/* && \
+    cd hmatrix/* && \
     sed -i 's/def __APPLE__/ 1/' src/C/vector-aux.c && \
     cabal install --global --only-dependencies && \
     cabal install --global -f openblas && \
-    cd /tmp && \
-    rm -rf hmatrix
+    : Clean up to keep the image small && \
+    rm -rf /tmp/*
 
 # TODO: network-protocol-xmpp supports libgsasl only, not cyrus-sasl-dev,
 #       either have to fix that or put a libgsasl-dev into Alpine

--- a/ghc-musl/Dockerfile
+++ b/ghc-musl/Dockerfile
@@ -44,17 +44,15 @@ RUN : "Layer 2: cabal-install, but only the binary, no executables" && \
     rm -rf /tmp/* /root/.ghc /root/.cabal/{lib,share}
 
 WORKDIR /root/.cabal
-RUN : "Layer 3: cabal-install from stackage and stackage is set up" && \
+RUN : "Layer 3: install stack" && \
     cabal update && \
-    curl -L 'https://www.stackage.org/lts/cabal.config?global=true' >>config && \
-    cabal install --global cabal-install && \
-    : We regenerate the config with the stackage cabal, so that they are compatible. && \
-    cabal update && \
+    cabal install --global stack && \
+    stack setup && \
     : Clean up to keep the image small && \
-    rm -rf /tmp/*
+    rm -rf /root/.cabal
 
 WORKDIR /tmp
-RUN : "Layer 4: install some packages" && \
+RUN : "Layer 4: install packages" && \
     : the ncurses hackage package is a little bit broken && \
     ln -s /usr/include /usr/include/ncursesw && \
     apk add curl-dev openssl-dev zeromq-dev libx11-dev libxkbfile-dev libxfont-dev \
@@ -64,77 +62,58 @@ RUN : "Layer 4: install some packages" && \
             libxmu-dev libxext-dev libxdamage-dev libxxf86vm-dev libxi-dev libxrandr-dev \
             libxres-dev libxcursor-dev libxrender-dev libxvmc-dev fuse-dev \
             mesa-dev glu-dev freeglut-dev gtk+2.0-dev && \
-    cabal install --global alex happy && \
-    cabal install --global c2hs && \
-    cabal install --global gtk2hs-buildtools && \
-    cabal install --global gtk chart-gtk && \
-    cabal install --global haskell-src haskell-src-exts haskell-src-meta && \
-    cabal install --global Glob HUnit Hfuse HsOpenSSL MissingH QuickCheck SafeSemaphore \
-                           X11 acid-state async attoparsec basic-prelude bytedump \
-                           classy-prelude-conduit clock colour conduit conduit-combinators \
-                           conduit-extra cookie criterion crypto-api crypto-pubkey \
-                           cryptohash curl data-accessor-template data-default data-memocombinators \
-                           digest direct-sqlite distributed-process double-conversion elerea fgl \
-                           filemanip foldl hamlet hashable haskeline hflags hit hslogger hspec html \
-                           http-client http-client-tls http-conduit http-types hybrid-vectors \
-                           kan-extensions lens lens-datetime linear mime-mail modular-arithmetic \
-                           monad-loops multimap ncurses netwire network-conduit network-transport-tcp \
-                           parallel parsers path-pieces persistent persistent-template pipes \
-                           pipes-bytestring pipes-safe pipes-zlib pretty-show primitive random-fu \
-                           regex-base regex-compat regex-posix regex-tdfa regex-tdfa-rc regex-tdfa-text \
-                           safecopy shakespeare shakespeare-css snap snap-blaze snap-core sodium split \
-                           sqlite-simple statistics statvfs syb tasty tasty-hunit temporary \
-                           test-framework test-framework-hunit test-framework-quickcheck2 test-framework-th \
-                           thyme tls trifecta tz tzdata unbounded-delays unix-bytestring \
-                           unix-time unordered-containers utf8-string utility-ht uuid vector \
-                           vector-algorithms vector-th-unbox x509 xml-conduit xtest yesod \
-                           yesod-static zeromq4-haskell zip-archive zlib-conduit && \
+    stack install HUnit HsOpenSSL MissingH QuickCheck SafeSemaphore X11 acid-state \
+                  alex async attoparsec basic-prelude bytedump c2hs classy-prelude-conduit \
+                  clock colour conduit conduit-combinators conduit-extra cookie \
+                  criterion crypto-api crypto-pubkey cryptohash curl data-accessor-template \
+                  data-default data-memocombinators digest direct-sqlite distributed-process \
+                  double-conversion elerea fgl filemanip foldl gtk gtk2hs-buildtools hamlet happy \
+                  hashable haskeline haskell-src haskell-src-exts haskell-src-meta \
+                  hflags hit hslogger hspec html http-client http-client-tls \
+                  http-conduit http-types hybrid-vectors kan-extensions lens lens-datetime \
+                  linear mime-mail modular-arithmetic monad-loops multimap ncurses \
+                  netwire network-conduit network-transport-tcp parallel parsers \
+                  path-pieces persistent persistent-template pipes pipes-bytestring \
+                  pipes-safe pipes-zlib pretty-show primitive random-fu regex-base \
+                  regex-compat regex-posix regex-tdfa regex-tdfa-rc regex-tdfa-text \
+                  safecopy shakespeare shakespeare-css snap snap-blaze snap-core \
+                  sodium split sqlite-simple statistics statvfs syb tasty tasty-hunit \
+                  temporary test-framework test-framework-hunit test-framework-quickcheck2 \
+                  test-framework-th thyme tls trifecta tz tzdata unbounded-delays \
+                  unix-bytestring unix-time unordered-containers utf8-string utility-ht \
+                  uuid vector vector-algorithms vector-th-unbox x509 xml-conduit \
+                  xtest yesod yesod-static zeromq4-haskell zip-archive zlib-conduit && \
     : template-default needs jailbreaking && \
-    cabal unpack -d template-default template-default && \
-    cd template-default/* && \
-    sed s/2.9/2.10/ -i template-default.cabal && \
-    cabal install --global --only-dependencies && \
-    cabal install --global && \
-    cd /tmp && \
-    : gloss needs some love and a big pile of jailbreaking && \
-    cabal unpack -d gloss-rendering gloss-rendering-1.9.2.1 && \
-    cd gloss-rendering/* && \
-    sed -i 's/GLUT.*/GLUT,/' gloss-rendering.cabal && \
-    sed -i 's/OpenGL.*/OpenGL,/' gloss-rendering.cabal && \
-    cabal install --global --only-dependencies && \
-    cabal install --global && \
-    cd /tmp && \
-    cabal unpack -d gloss gloss-1.9.2.1 && \
-    cd gloss/* && \
-    sed -i 's/GLUT.*==.*/GLUT,/' gloss.cabal && \
-    sed -i 's/OpenGL.*==.*/OpenGL,/' gloss.cabal && \
-    cabal install --global --only-dependencies && \
-    cabal install --global && \
-    cd /tmp && \
+    stack unpack template-default && \
+    cd template-default-* && \
+    sed -i 's/2.9/2.10/' template-default.cabal && \
+    stack init && \
+    stack install && \
     : deepseq-th jailbreaking && \
-    cabal unpack -d deepseq-th deepseq-th && \
-    cd deepseq-th/* && \
+    cd /tmp && \
+    stack unpack deepseq-th && \
+    cd deepseq-th-* && \
     sed -i 's/base.*,/base,/' deepseq-th.cabal && \
     sed -i 's/2.9/2.10/' deepseq-th.cabal && \
-    cabal install --global --only-dependencies && \
-    cabal install --global && \
+    stack init && \
+    stack install && \
     cd /tmp && \
     : "bindings-posix fixes: musl has no POSIX2_{CHAR_TERM,LOCALEDEF}" && \
-    cabal unpack -d bindings-posix bindings-posix && \
-    cd bindings-posix/* && \
+    stack unpack bindings-posix && \
+    cd bindings-posix-* && \
     sed -i 's/#num _POSIX2_CHAR_TERM//' src/Bindings/Posix/Unistd.hsc && \
     sed -i 's/#num _POSIX2_LOCALEDEF//' src/Bindings/Posix/Unistd.hsc && \
-    cabal install --global --only-dependencies && \
-    cabal install --global && \
+    stack init && \
+    stack install && \
     cd /tmp && \
     : "hmatrix should use random in musl, not random_r, also openblas..." && \
     echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
     apk add --update openblas-dev@testing && \
-    cabal unpack -d hmatrix hmatrix && \
-    cd hmatrix/* && \
+    stack unpack hmatrix && \
+    cd hmatrix-* && \
     sed -i 's/def __APPLE__/ 1/' src/C/vector-aux.c && \
-    cabal install --global --only-dependencies && \
-    cabal install --global -f openblas && \
+    stack init && \
+    stack install --flag hmatrix:openblas && \
     : Clean up to keep the image small && \
     rm -rf /tmp/*
 

--- a/packages.txt
+++ b/packages.txt
@@ -380,4 +380,3 @@
     zlib-bindings-0.1.1.5
     zlib-conduit-1.1.0
     zlib-enum-0.2.3.1
-


### PR DESCRIPTION
This branch replaces cabal with stack.

EDIT: after more reflection on this, it's possible I took the stack replacement too far. However, I arranged the commits in this branch so that it would be possible to remove the second-to-last commit and still have some value in the cleanup of the existing `Dockerfile`.

[Fix #3]
